### PR TITLE
Restrict workflow run condition

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,7 @@
 name: CI/CD
 on:
   push:
+    branches: [ main ]
   pull_request:
   release:
     types: [ published ]


### PR DESCRIPTION
Restrict the GitHub workflow to only run when pushing to main, submitting pull requests, and when publishing release