### PR TITLE
Fix freebie ID not found error

### DIFF
--- a/crates/freebie/src/purchase_order.rs
+++ b/crates/freebie/src/purchase_order.rs
@@ -38,12 +38,15 @@ pub fn generate_purchase_order_report<R: AsRef<str>>(
         .set_value(freebie.order_number_cell_value(order_number));
 
     // Get the freebie ID
-    let first_item_needs = item_needs_slice.first().ok_or(Error::ItemNeedsEmpty)?;
-    let id = first_item_needs
-        .get_all_items()
-        .into_iter()
-        .find(|item| item.title == freebie.name())
-        .map(|item| item.id)
+    let id = item_needs_slice
+        .iter()
+        .find_map(|item_needs| {
+            item_needs
+                .get_all_items()
+                .into_iter()
+                .find(|item| item.title == freebie.name())
+                .map(|item| item.id)
+        })
         .ok_or(Error::FreebieNotFound)?;
 
     // Set the item needs


### PR DESCRIPTION
The `GetItemNeedCount` API may return different dynamic columns when there are no stations submitting item need for specific freebie. The code handling freebie name-id mapping didn't handle this situation well, as it only check the dynamic column items of the first ItemNeeds in slice. Now it checked all the ItemNeeds in slice to thoroughly find whether the specific freebie exists in all operation centers records.